### PR TITLE
infra: setup auto-tagging and publishing on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   lint:
@@ -41,22 +41,57 @@ jobs:
       - name: Run tests with coverage
         run: sbt clean coverage test coverageReport
 
-  publish:
+  release:
     needs: [lint, test]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # Only run on push to main, not on tags (to avoid double publishing if we pushed the tag)
+    # But wait, if we push the tag, we want to publish? 
+    # The plan is: merge to main -> calculate version -> tag -> publish -> push tag.
+    # So we only need to run this on push to main.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'
           cache: 'sbt'
+      
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
+
+      - name: Configure Git User
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Calculate Next Version and Tag
+        id: tag
+        run: |
+          # Get the latest tag, default to v0.0.0 if none
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "Latest tag: $LATEST_TAG"
+          
+          # Split into parts
+          VERSION=${LATEST_TAG#v}
+          IFS='.' read -r -a PARTS <<< "$VERSION"
+          MAJOR=${PARTS[0]}
+          MINOR=${PARTS[1]}
+          PATCH=${PARTS[2]}
+          
+          # Increment patch
+          NEW_PATCH=$((PATCH + 1))
+          NEW_TAG="v$MAJOR.$MINOR.$NEW_PATCH"
+          echo "New tag: $NEW_TAG"
+          
+          # Tag locally
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
       - name: Publish to Maven Central
         run: sbt ci-release
         env:
@@ -64,3 +99,6 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      
+      - name: Push Tag
+        run: git push origin ${{ steps.tag.outputs.tag }}

--- a/build.sbt
+++ b/build.sbt
@@ -33,8 +33,7 @@ lazy val root = project
   .in(file("."))
   .settings(
     commonSettings,
-    name    := "gemini4s",
-    version := "0.1.0-SNAPSHOT",
+    name := "gemini4s",
 
     // Publishing settings
     organization := "com.github.jamesmiller",
@@ -56,11 +55,11 @@ lazy val root = project
     ),
 
     // Scoverage settings
-    coverageMinimumStmtTotal := 80,
+    coverageMinimumStmtTotal   := 80,
     coverageMinimumBranchTotal := 90,
-    coverageFailOnMinimum    := true,
-    coverageHighlighting     := true,
-    coverageExcludedPackages := "<empty>;Reverse.*;.*AuthService.*;models\\.data\\..*",
+    coverageFailOnMinimum      := true,
+    coverageHighlighting       := true,
+    coverageExcludedPackages   := "<empty>;Reverse.*;.*AuthService.*;models\\.data\\..*",
     addCommandAlias("lint", ";scalafixAll --check; testCoverage"),
     addCommandAlias("lintFix", ";scalafixAll"),
     addCommandAlias("testCoverage", ";clean;coverage;test;coverageReport"),


### PR DESCRIPTION
infra: setup auto-tagging and publishing on merge to main

## Description
This PR updates the CI configuration to automatically manage releases when changes are merged into the `main` branch.

### Changes
- **build.sbt**: Removed the hardcoded `version := "0.1.0-SNAPSHOT"`. The project now uses `sbt-dynver` to derive the version from git tags.
- **.github/workflows/ci.yml**:
    - Added `contents: write` permission to the workflow.
    - Replaced the `publish` job with a `release` job that runs only on pushes to `main`.
    - Implemented logic to:
        1. Calculate the next patch version based on the latest git tag.
        2. Create a new git tag.
        3. Publish artifacts to Maven Central using `sbt ci-release`.
        4. Push the new tag back to the repository.

## Verification
- Verified locally that `sbt version` correctly picks up the dynamic version (e.g., `0.0.0+...-SNAPSHOT`).
- The CI workflow has been updated to include these steps, which will execute upon merge.