### PR TITLE
infra: fix release detection by setting CI_COMMIT_TAG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
       - name: Publish to Maven Central
         run: sbt ci-release
         env:
+          CI_COMMIT_TAG: ${{ steps.tag.outputs.tag }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
Injects CI_COMMIT_TAG into the release environment to ensure sbt-ci-release treats the build as a release.