### PR TITLE
Fix navigation duplication by disabling default page links

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,9 @@ lazy val docs = project
         )
         .site
         .mainNavigation(
-          appendLinks = Seq(
+          0,
+          false,
+          Seq(
             ThemeNavigationSection(
               "Getting Started",
               TextLink.internal(Root / "quickstart.md", "Quick Start")


### PR DESCRIPTION
# Microsite Navigation Fix

This PR resolves the issue where navigation links were duplicated in the microsite sidebar.

## Changes
- **build.sbt**: Set `mainNavigation` depth to `0` and `includePageLinks` to `false` (via positional arguments).
  - This disables the auto-generated file tree navigation.
  - Ensures only the manually defined sections (Getting Started, Core Concepts, Features, Reference) are displayed.

## Verification
- **Local Build**: Verified with `sbt docs/tlSite`.
- **Browser Tour**: Confirmed locally that the sidebar is clean and structured correctly without duplicates.
- **Artifacts**: Updated `walkthrough.md` with a recording of the fixed local navigation.