### PR TITLE
Fix documentation versioning to use stable release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,13 @@ lazy val docs = project
     // mdoc settings for type-checked examples
     mdocIn        := file("docs"),
     mdocVariables := Map(
-      "VERSION" -> version.value
+      "VERSION" -> {
+        if (isSnapshot.value) {
+          previousStableVersion.value.getOrElse("0.0.1")
+        } else {
+          version.value
+        }
+      }
     ),
 
     // Site configuration


### PR DESCRIPTION
This PR fixes an issue where the documentation would display a snapshot version (e.g. `0.0.9+...`) instead of the latest stable release (e.g. `0.0.9`).

## Changes
- Updated `build.sbt` to use `previousStableVersion` for `mdocVariables` when the build is a snapshot.

This ensures that the deployed documentation always shows a clean, usable version number for users.