### PR TITLE
Fix documentation versioning with deep fetch and robust fallback

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - uses: actions/setup-java@v4
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,10 @@ lazy val docs = project
     mdocVariables := Map(
       "VERSION" -> {
         if (isSnapshot.value) {
-          previousStableVersion.value.getOrElse("0.0.1")
+          // Try to get the last stable version, falling back to git describe, then current version
+          previousStableVersion.value
+            .orElse(scala.util.Try(scala.sys.process.Process("git describe --tags --abbrev=0").!!.trim).toOption)
+            .getOrElse(version.value)
         } else {
           version.value
         }


### PR DESCRIPTION
This PR fixes the documentation versioning issue where snapshots were displayed instead of stable releases.

## The Fix
1. **Deep Clone**: Updated `docs.yml` to use `fetch-depth: 0`. This is critical for `sbt-dynver` to find git tags and determine `previousStableVersion`.
2. **Robust Fallback**: Updated `build.sbt` to try `previousStableVersion`, then `git describe`, and finally fall back to `version.value`.

This ensures that even if sbt metadata is missing, we attempt to get the latest tag directly from git.