### PR TITLE
Infra: Push Tag Before Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
           git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
           echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
+      - name: Push Tag
+        if: github.ref == 'refs/heads/main'
+        run: git push origin ${{ steps.tag.outputs.tag }}
+
       - name: Publish
         env:
           CI_COMMIT_TAG: ${{ steps.tag.outputs.tag }}
@@ -123,10 +127,6 @@ jobs:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
         run: sbt ci-release
-
-      - name: Push Tag
-        if: github.ref == 'refs/heads/main'
-        run: git push origin ${{ steps.tag.outputs.tag }}
 
       - name: Create GitHub Release
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
This PR updates the CI workflow to push the calculated tag to the repository *before* attempting to publish to Maven Central. This ensures that the tag exists even if the publish step fails, improving traceability and potentially stability for sbt-ci-release.