### PR TITLE
build: Set versionScheme to early-semver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val root = project
       Developer(
         "jamesmiller",
         "James Miller",
-        "",
+        "7511223+JamesMMiller@users.noreply.github.com",
         url("https://github.com/JamesMMiller")
       )
     ),


### PR DESCRIPTION
This PR sets the `versionScheme` to `early-semver` in `build.sbt` to resolve the SBT warning and ensure proper eviction handling.