### PR TITLE
docs: Fix contributing link in microsite index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ See the [Models Guide](models.md) for detailed comparison and selection guidance
 
 - **GitHub**: [JamesMMiller/gemini4s](https://github.com/JamesMMiller/gemini4s)
 - **Issues**: [Report bugs or request features](https://github.com/JamesMMiller/gemini4s/issues)
-- **Contributing**: See [CONTRIBUTING.md](https://github.com/JamesMMiller/gemini4s/blob/main/CONTRIBUTING.md)
+- **Contributing**: See [Contributing Guide](contributing.md)
 
 ## License
 


### PR DESCRIPTION
This PR fixes the broken link to the contributing guide in `docs/index.md` by using a relative path instead of an absolute GitHub URL.