### PR TITLE
docs: Remove misleading 'retry strategies' claim

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ gemini4s is a **purely functional**, **type-safe**, and **idiomatic** Scala 3 li
 - 🛡️ **Type-Safe**: Strongly typed models for requests, responses, and configuration
 - 🌊 **Streaming**: Native FS2 streaming for real-time responses
 - 🧩 **Composable**: Built on Cats Effect 3 for seamless integration
-- 🛡️ **Robust**: Comprehensive error handling and retry strategies
+- 🛡️ **Robust**: Comprehensive error handling
 - 🛠️ **Feature Complete**: Supports content generation, embeddings, function calling, caching, and more
 
 ## Quick Start


### PR DESCRIPTION
This PR removes the claim that the library implements 'retry strategies' from the documentation, as this feature is not currently implemented in the codebase (though examples are provided in the docs).

### Changes
- **docs/index.md**: Removed 'and retry strategies' from the Features list.