### PR TITLE
fix: Restore service instance in integration tests

### DIFF
--- a/integration/src/test/scala/gemini4s/GeminiIntegrationSpec.scala
+++ b/integration/src/test/scala/gemini4s/GeminiIntegrationSpec.scala
@@ -618,6 +618,7 @@ class GeminiIntegrationSpec extends CatsEffectSuite {
     withBackend { backend =>
       val apiKeyValue = ApiKey.unsafe(apiKey.getOrElse("mock-key"))
       val httpClient  = GeminiHttpClient.make[IO](backend, apiKeyValue)
+      val service     = GeminiService.make[IO](httpClient)
       val model       = ModelName.Gemini25Flash
       val requests    = List(
         GenerateContentRequest(model, List(GeminiService.text("Test prompt 1"))),


### PR DESCRIPTION
Fixes compilation error in GeminiIntegrationSpec caused by missing service definition.